### PR TITLE
Fix size of TxToken buffer

### DIFF
--- a/src/rt1062_eth/mod.rs
+++ b/src/rt1062_eth/mod.rs
@@ -184,7 +184,7 @@ impl<'a, const INST: u8, const MTU: usize, const TX_LEN: usize> phy::TxToken
     where
         F: FnOnce(&mut [u8]) -> R,
     {
-        let result = f(&mut self.txdt.bufs[*self.tx_pos]);
+        let result = f(&mut self.txdt.bufs[*self.tx_pos][..len]);
         let desc: &mut TxDescriptor = &mut self.txdt.desc[*self.tx_pos];
         desc.len = len as u16;
         desc.flags |= 0x8C00;


### PR DESCRIPTION
`TxToken::consume` asks that we construct a buffer of size `len`. If we don't, we [hit an assert](https://github.com/smoltcp-rs/smoltcp/blob/cfc17ba16d3fdadb3f86e2d5b326af3797284b22/src/iface/interface/ethernet.rs#L65) in debug builds.